### PR TITLE
catch ilpy v3 solution type

### DIFF
--- a/structsvm/bundle_method.py
+++ b/structsvm/bundle_method.py
@@ -3,6 +3,7 @@ import numpy as np
 import ilpy
 
 logger = logging.getLogger(__name__)
+ILPY_V02 = ilpy.__version__.split(".")[:2] < ["0", "3"]
 
 
 class BundleMethod:
@@ -174,7 +175,7 @@ class BundleMethod:
     def _find_min_lower_bound(self):
 
         # solve the QP
-        solution, _ = self._solver.solve()
+        solution = self._solver.solve()[0] if ILPY_V02 else self._solver.solve()
 
         # read the solution
         w = np.array([solution[i] for i in range(self._dims)])

--- a/structsvm/soft_margin_loss.py
+++ b/structsvm/soft_margin_loss.py
@@ -4,7 +4,7 @@ import ilpy
 from .hamming_costs import HammingCosts
 
 logger = logging.getLogger(__name__)
-
+ILPY_V02 = ilpy.__version__.split(".")[:2] < ["0", "3"]
 
 class SoftMarginLoss:
     '''Implements the soft margin loss, i.e.,
@@ -96,7 +96,8 @@ class SoftMarginLoss:
 
         # solve
         self._solver.set_objective(self._objective)
-        solution, _ = self._solver.solve()
+        # solve the QP
+        solution = self._solver.solve()[0] if ILPY_V02 else self._solver.solve()
 
         # read optimal value L(w)
         value = solution.get_value()

--- a/tests/test_bundle_method.py
+++ b/tests/test_bundle_method.py
@@ -14,4 +14,4 @@ def test_quadratic():
         eps=1e-5)
 
     w = bundle_method.optimize(max_iterations=100)
-    assert round(w[0], 5) == 0.99897
+    assert round(w[0], 4) == 0.9990


### PR DESCRIPTION
https://github.com/funkelab/ilpy/pull/30 will soon be released that will break structsvm's usage of solver.solve()

this PR catches and fixes that.  Later we can pin to ilpy > 0.3 and remove the conditional